### PR TITLE
disable proxy code

### DIFF
--- a/supybot_meetbot/plugin.py
+++ b/supybot_meetbot/plugin.py
@@ -268,6 +268,10 @@ class MeetBot(callbacks.Plugin):
         To enable this, you must comment out a line in the main code.
         It may be enabled in a future version.
         """
+        
+        # this is disabled comment out this return line to enable
+        return
+
         # First, proxy to our parent classes (__parent__ set in __init__)
         try:
             return self.__parent.__getattr__(name)


### PR DESCRIPTION
the code to "Proxy between proper supybot commands and # MeetBot commands"
was causing issues when loading the plugin on python3. this adds a
return before any code to make sure that the code is not running

Resolves: #2

Signed-off-by: Ryan Lerch <rlerch@redhat.com>