### PR TITLE
add support for fedora messaging

### DIFF
--- a/supybot-meetbot.spec
+++ b/supybot-meetbot.spec
@@ -12,6 +12,7 @@ Requires:       limnoria
 Requires:       python3-pygments
 Requires:       python3-docutils
 Requires:       python3-kitchen
+Requires:       fedora-messaging
 
 BuildArch:      noarch
 BuildRequires:  python3-devel


### PR DESCRIPTION
This adds the logic that was previously housed in supybot-fedmsg that
sent fedora-messages.