### PR TITLE
remove experimental Proxy between proper supybot commands and # MeetB…

### DIFF
--- a/supybot_meetbot/plugin.py
+++ b/supybot_meetbot/plugin.py
@@ -258,51 +258,6 @@ class MeetBot(callbacks.Plugin):
 
     pingall = wrap(pingall, [optional('text', None)])
 
-    def __getattr__(self, name):
-        """Proxy between proper supybot commands and # MeetBot commands.
-
-        This allows you to use MeetBot: <command> <line of the command>
-        instead of the typical #command version.  However, it's disabled
-        by default as there are some possible unresolved issues with it.
-
-        To enable this, you must comment out a line in the main code.
-        It may be enabled in a future version.
-        """
-        
-        # this is disabled comment out this return line to enable
-        return
-
-        # First, proxy to our parent classes (__parent__ set in __init__)
-        try:
-            return self.__parent.__getattr__(name)
-        except AttributeError:
-            pass
-        # Disabled for now.  Uncomment this if you want to use this.
-        raise AttributeError
-
-        if not hasattr(meeting.Meeting, "do_"+name):
-            raise AttributeError
-
-        def wrapped_function(self, irc, msg, args, message):
-            channel = msg.args[0]
-            payload = msg.args[1]
-
-            #from fitz import interactnow ; reload(interactnow)
-
-            #print type(payload)
-            payload = "#%s %s"%(name,message)
-            #print payload
-            import copy
-            msg = copy.copy(msg)
-            msg.args = (channel, payload)
-
-            self.doPrivmsg(irc, msg)
-        # Give it the signature we need to be a callable supybot
-        # command (it does check more than I'd like).  Heavy Wizardry.
-        instancemethod = type(self.__getattr__)
-        wrapped_function = wrap(wrapped_function, [optional('text', '')])
-        return instancemethod(wrapped_function, self, MeetBot)
-
 Class = MeetBot
 
 


### PR DESCRIPTION
…ot commands

this expetimental feature that was commented out apparently allowed you to use

MeetBot: <command> <line of the command>

instead of the typical #command version.

However, having this code still in place was causing issues with the
normal non-meeting commands (listmeetings, recent etc), and was also
causing supybot to throw an exception when any non-recognised command
was issued (e.g. ".mypants")

this commit removes this old unused code.

Resolves: #18
Resolves: #20

Signed-off-by: Ryan Lerch <rlerch@redhat.com>